### PR TITLE
Deploy mongo with auth enabled

### DIFF
--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -26,6 +26,10 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
 )
 
+// errNoSuchInstance implements the Error interface.
+// This struct handles the common error of an unrecogonzied instanceID
+// and should be used as a returned error value.
+// e.g. return errNoSuchInstance{instanceID: <id>}
 type errNoSuchInstance struct {
 	instanceID string
 }
@@ -34,24 +38,35 @@ func (e errNoSuchInstance) Error() string {
 	return fmt.Sprintf("No such instance with ID %s", e.instanceID)
 }
 
+// userProvidedServiceInstance contains identifying data for each existing service instance.
 type userProvidedServiceInstance struct {
+	// Id is the instanceID
 	Id         string                   `json:"id"`
+	// Namespace is the k8s namespace provided in the CreateServiceInstanceReqeust.ContextProfile.Namespace
 	Namespace  string                   `json:"namespace"`
+	// ServiceID is the service's associated id.
 	ServiceID  string                   `json:"serviceid"`
+	// Credential is the binding credential created during Bind()
 	Credential *brokerapi.Credential    `json:"credential"`
 }
 
+// userProvidedController implements the OSB API and represents the actual Broker.
 type userProvidedController struct {
+	// rwMutex controls concurrent R and RW access.
 	rwMutex     sync.RWMutex
+	// instanceMap should take instanceIDs as the key and maps to that ID's userProvidedServiceInstance
 	instanceMap map[string]*userProvidedServiceInstance
 }
 
 const (
+	// Service IDs should always be constants.  The variable names should be prefixed with "serviceid"
+	// serviceidUserProvided is the basic demo. It provides no actual service
 	serviceidUserProvided string = "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+	// serviceidDatabasePod  provides an instance of a mongo db
 	serviceidDatabasePod  string = "database-1"
 )
 
-// CreateController creates an instance of a User Provided service broker controller.
+// CreateController initializes the service broker.  This function is called by server.Start()
 func CreateController() controller.Controller {
 	var instanceMap = make(map[string]*userProvidedServiceInstance)
 	return &userProvidedController{
@@ -59,6 +74,8 @@ func CreateController() controller.Controller {
 	}
 }
 
+// Catalog is an OSB method.  It returns a slice of services.
+// New services should be specified here.
 func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
 	glog.Info("[DEBUG] Handling Catalog Request")
 	return &brokerapi.Catalog{
@@ -94,6 +111,9 @@ func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
 	}, nil
 }
 
+// CreateServiceInstance is an OSB method.  It handles provisioning of service instances
+// as determined by the instance's serviceID.
+// New services should be added as a new case in the switch.
 func (c *userProvidedController) CreateServiceInstance(
 	id string,
 	req *brokerapi.CreateServiceInstanceRequest,
@@ -127,6 +147,7 @@ func (c *userProvidedController) CreateServiceInstance(
 	return nil, nil
 }
 
+// GetServiceInstance is an OSB method. It gets an instance by the instance's ID and returns it as a json string.
 func (c *userProvidedController) GetServiceInstance(id string) (string, error) {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
@@ -141,6 +162,8 @@ func (c *userProvidedController) GetServiceInstance(id string) (string, error) {
 	return string(instance), nil
 }
 
+// RemoveServiceInstance is an OSB method.  It handles deprovisioning determined by the serviceID.
+// New services should be added as a new case in the switch.
 func (c *userProvidedController) RemoveServiceInstance(id string) (*brokerapi.DeleteServiceInstanceResponse, error) {
 	c.rwMutex.Lock()
 	defer c.rwMutex.Unlock()
@@ -153,6 +176,7 @@ func (c *userProvidedController) RemoveServiceInstance(id string) (*brokerapi.De
 	}
 	switch c.instanceMap[id].ServiceID {
 	case serviceidUserProvided:
+		// Do nothing.
 	case serviceidDatabasePod:
 		if err := doDBDeprovision(id, c.instanceMap[id].Namespace); err != nil {
 			err = fmt.Errorf("Error deprovisioning instance %q, %v", id, err)
@@ -165,6 +189,8 @@ func (c *userProvidedController) RemoveServiceInstance(id string) (*brokerapi.De
 	return nil, nil
 }
 
+// Bind is an OSB method.  It handles bindings as determined by the serviceID.
+// New services should be added as a new case in the switch.
 // TODO implment bindMap to track db bindings (user, bindId, etc.)
 func (c *userProvidedController) Bind(
 	instanceID,
@@ -204,7 +230,9 @@ func (c *userProvidedController) Bind(
 	return &brokerapi.CreateServiceBindingResponse{Credentials: *newCredential}, nil
 }
 
-//TODO implement DB unbinding
+// UnBind is an OSB method.  It handles credentials deletion relative to each service.
+// New services should be added as a new case in the switch.
+//TODO implement DB unbinding (delete user, etc)
 func (c *userProvidedController) UnBind(instanceID string, bindingID string) error {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
@@ -217,7 +245,7 @@ func (c *userProvidedController) UnBind(instanceID string, bindingID string) err
 	}
 	switch instance.ServiceID {
 	case serviceidUserProvided:
-		// nothing to do
+		// Do nothing
 	case serviceidDatabasePod:
 		doDBUnbind()
 	}

--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -102,56 +102,38 @@ func (c *userProvidedController) CreateServiceInstance(
 	defer c.rwMutex.Unlock()
 
 	//DEBUG
-	glog.Info("[DEBUG] New CreateServiceInstanceRequest (ID: %q)", id)
+	glog.Info("[DEBUG] Create ServiceInstance Request (ID: %q)", id)
 
 	if _, ok := c.instanceMap[id]; ok {
 		return nil, fmt.Errorf("Instance %q already exists", id)
 	}
 	// Create New Instance
-	c.instanceMap[id] = &userProvidedServiceInstance{
+	newInstance := &userProvidedServiceInstance{
 		Id:        id,
 		ServiceID: req.ServiceID,
+		Namespace: req.ContextProfile.Namespace,
 	}
-
-	// Extract credentials from request or generate dummy
-	credString, ok := req.Parameters["credentials"]
-	if ok {
-		jsonCred, err := json.Marshal(credString)
-		if err != nil {
-			glog.Errorf("Failed to marshal credentials: %v", err)
-			return nil, err
-		}
-		var cred brokerapi.Credential
-		err = json.Unmarshal(jsonCred, &cred)
-		c.instanceMap[id].Credential = &cred
-	} else {
-		c.instanceMap[id].Credential = &brokerapi.Credential{
-			"special-key-1": "special-value-1",
-			"special-key-2": "special-value-2",
-		}
-	}
-
 	// Do provisioning logic based on service id
-	switch c.instanceMap[id].ServiceID {
+	switch newInstance.ServiceID {
 	case serviceidUserProvided:
 		break
 	case serviceidDatabasePod:
-		ns, err := provisionDBInstance(id, req.ContextProfile.Namespace)
+		err := doDBProvision(id, newInstance.Namespace)
 		if err != nil {
 			return nil, err
 		}
-		c.instanceMap[id].Namespace = ns
 	}
-	glog.Infof("Provisioned Instance: %q", c.instanceMap[id].Id)
+	glog.Infof("Provisioned Instance %q in Namespace %q", newInstance.Id, newInstance.Namespace)
+	c.instanceMap[id] = newInstance
 	return nil, nil
 }
 
 func (c *userProvidedController) GetServiceInstance(id string) (string, error) {
-	c.rwMutex.Lock()
-	defer c.rwMutex.Unlock()
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
 
 	// DEBUG
-	glog.Infof("[DEBUG] GetServiceInstance, ID: %q", id)
+	glog.Infof("[DEBUG] Get ServiceInstance Request (ID: %q)", id)
 
 	if _, ok := c.instanceMap[id]; ! ok {
 		return "", errNoSuchInstance{instanceID: id }
@@ -165,7 +147,7 @@ func (c *userProvidedController) RemoveServiceInstance(id string) (*brokerapi.De
 	defer c.rwMutex.Unlock()
 
 	// DEBUG
-	glog.Infof("[DEBUG] RemoveServiceInstance %q", id)
+	glog.Infof("[DEBUG] Remove ServiceInstance Request (ID: %q)", id)
 
 	if _, ok := c.instanceMap[id]; ! ok {
 		return nil, errNoSuchInstance{instanceID: id}
@@ -174,7 +156,7 @@ func (c *userProvidedController) RemoveServiceInstance(id string) (*brokerapi.De
 	case serviceidUserProvided:
 		break
 	case serviceidDatabasePod:
-		if err := deprovisionDBInstance(id, c.instanceMap[id].Namespace); err != nil {
+		if err := doDBDeprovision(id, c.instanceMap[id].Namespace); err != nil {
 			err = fmt.Errorf("Error deprovisioning instance %q, %v", id, err)
 			glog.Error(err)
 			return nil, err
@@ -185,6 +167,7 @@ func (c *userProvidedController) RemoveServiceInstance(id string) (*brokerapi.De
 	return nil, nil
 }
 
+// TODO implment bindMap to track db bindings (user, bindId, etc.)
 func (c *userProvidedController) Bind(
 	instanceID,
 	bindingID string,
@@ -192,30 +175,53 @@ func (c *userProvidedController) Bind(
 ) (*brokerapi.CreateServiceBindingResponse, error) {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
+
+	// DEBUG
+	glog.Infof("[DEBUG] Bind ServiceInstance Request (ID: %q)", instanceID)
+
 	instance, ok := c.instanceMap[instanceID]
 	if !ok {
 		return nil, errNoSuchInstance{instanceID: instanceID}
 	}
+	var newCredential *brokerapi.Credential
 	switch c.instanceMap[instanceID].ServiceID {
 	case serviceidUserProvided:
-		break
+		// Extract credentials from request or generate dummy
+		newCredential = &brokerapi.Credential{
+			"special-key-1": "special-value-1",
+			"special-key-2": "special-value-2",
+		}
 	case serviceidDatabasePod:
-		podIP, podPort, err := getInstancePodIP(c.instanceMap[instanceID])
+		ip, port, err := doDBBind(instanceID, instance.Namespace)
 		if err != nil {
 			return nil, err
 		}
-		return &brokerapi.CreateServiceBindingResponse{
-			Credentials: brokerapi.Credential{
-				"mongo_svc_ip_port": fmt.Sprintf("%s:%d", podIP, podPort),
-			},
-		}, nil
+		newCredential = &brokerapi.Credential{
+			"mongo_svc_ip_port": fmt.Sprintf("%s:%d", ip, port),
+		}
 	}
-	cred := instance.Credential
+	instance.Credential = newCredential
 	glog.Infof("Bound Instance: %q", instanceID)
-	return &brokerapi.CreateServiceBindingResponse{Credentials: *cred}, nil
+	return &brokerapi.CreateServiceBindingResponse{Credentials: *newCredential}, nil
 }
 
 //TODO implement DB unbinding
 func (c *userProvidedController) UnBind(instanceID string, bindingID string) error {
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
+	// DEBUG
+	glog.Infof("[DEBUG] Unind ServiceInstance Request (ID: %q)", instanceID)
+
+	instance, ok := c.instanceMap[instanceID]
+	if !ok {
+		return errNoSuchInstance{instanceID: instanceID}
+	}
+	switch instance.ServiceID {
+	case serviceidUserProvided:
+		// nothing to do
+	case serviceidDatabasePod:
+		doDBUnbind()
+	}
+	glog.Infof("Unbound Instance: %q", instanceID)
 	return nil
 }

--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -116,7 +116,6 @@ func (c *userProvidedController) CreateServiceInstance(
 	// Do provisioning logic based on service id
 	switch newInstance.ServiceID {
 	case serviceidUserProvided:
-		break
 	case serviceidDatabasePod:
 		err := doDBProvision(id, newInstance.Namespace)
 		if err != nil {
@@ -154,7 +153,6 @@ func (c *userProvidedController) RemoveServiceInstance(id string) (*brokerapi.De
 	}
 	switch c.instanceMap[id].ServiceID {
 	case serviceidUserProvided:
-		break
 	case serviceidDatabasePod:
 		if err := doDBDeprovision(id, c.instanceMap[id].Namespace); err != nil {
 			err = fmt.Errorf("Error deprovisioning instance %q, %v", id, err)
@@ -197,10 +195,11 @@ func (c *userProvidedController) Bind(
 			return nil, err
 		}
 		newCredential = &brokerapi.Credential{
-			"mongo_svc_ip_port": fmt.Sprintf("%s:%d", ip, port),
+			"mongoInstanceIp": ip,
+			"mongoInstancePort": port,
 		}
 	}
-	instance.Credential = newCredential
+	c.instanceMap[instanceID].Credential = newCredential
 	glog.Infof("Bound Instance: %q", instanceID)
 	return &brokerapi.CreateServiceBindingResponse{Credentials: *newCredential}, nil
 }

--- a/contrib/pkg/broker/user_provided/controller/controller_pod.go
+++ b/contrib/pkg/broker/user_provided/controller/controller_pod.go
@@ -8,41 +8,60 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-)
-const (
-	dbuser = "dbuser"
-	dbpwd  = "dbpwd"
 )
 
-func provisionInstancePod(nameSuffix, ns string) (string, string, error) {
+const (
+	MONGO_INITDB_ROOT_USERNAME_NAME  = "MONGO_INITDB_ROOT_USERNAME" // DO NOT CHANGE - must match docker image variable
+	MONGO_INITDB_ROOT_USERNAME_VALUE = "admin"
+	MONGO_INITDB_ROOT_PASSWORD_NAME  = "MONGO_INITDB_ROOT_PASSWORD" // DO NOT CHANGE - must match docker image variable
+	MONGO_INITDB_ROOT_PASSWORD_VALUE = "password"
+	INST_RESOURCE_LABEL_NAME         = "instanceId"
+)
+
+func provisionDBInstance(instanceID, ns string) (string, error) {
 	cs, err := getKubeClient()
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	if ns == "" {
 		glog.Error("Request Context does not contain a Namespace")
-		return "", "", errors.New("Namespace not detected in Request")
+		return "", errors.New("Namespace not detected in Request")
 	}
-	pod := newDatabasePod(nameSuffix, ns)
+	pod, sec := newDatabaseInstance(instanceID)
+	sec, err = cs.CoreV1().Secrets(ns).Create(sec)
+	if err != nil {
+		glog.Errorf("Failed to Create secret: %v", err)
+		return "", nil
+	}
 	pod, err = cs.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
+		cs.CoreV1().Secrets(ns).Delete(sec.Name, &metav1.DeleteOptions{})
 		glog.Errorf("Failed to Create pod: %q", err)
-		return "", "", err
-	} else {
-		glog.Infof("Provisioned Instance Pod %q (ns: %s)", pod.Name, ns)
+		return "", err
 	}
-	return pod.Name, pod.Namespace, nil
+	glog.Infof("Provisioned Instance Pod %q (ns: %s)", pod.Name, ns)
+	return pod.Namespace, nil
 }
 
-func deprovisionInstancePod(name, ns string) error {
+func deprovisionDBInstance(instanceID, ns string) error {
 	cs, err := getKubeClient()
 	if err != nil {
 		return err
 	}
-	glog.Infof("Deleting Instance pod %q (ns: %s)", name, ns)
-	err = cs.CoreV1().Pods(ns).Delete(name, &metav1.DeleteOptions{})
-	if ! apierrs.IsNotFound(err) {
+	glog.Infof("Deleting Instance Pod (ID: %v)", instanceID)
+	err = cs.CoreV1().Pods(ns).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: INST_RESOURCE_LABEL_NAME + "=" + instanceID,
+	})
+	if err != nil {
+		glog.Errorf("Error deleting Instance Pod (ID: %v): %v", instanceID, err)
+		return err
+	}
+	glog.Infof("Deleting Instance Secret (ID: %v)", instanceID)
+	err = cs.CoreV1().Secrets(ns).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: INST_RESOURCE_LABEL_NAME + "=" + instanceID,
+	})
+	if err != nil {
+		glog.Errorf("Error deleting Instance Secret (ID: %v): %v", instanceID, err)
 		return err
 	}
 	return nil
@@ -53,11 +72,14 @@ func getInstancePodIP(instance *userProvidedServiceInstance) (string, int32, err
 	if err != nil {
 		return "", 0, err
 	}
-	pod, err := cs.Pods(instance.PodNamespace).Get(instance.PodName, metav1.GetOptions{})
+	pods, err := cs.CoreV1().Pods(instance.Namespace).List(metav1.ListOptions{
+		LabelSelector: INST_RESOURCE_LABEL_NAME,
+		FieldSelector: instance.Id,
+	})
 	if err != nil {
 		return "", 0, err
 	}
-	return pod.Status.PodIP, pod.Spec.Containers[0].Ports[0].ContainerPort, nil
+	return pods.Items[0].Status.PodIP, pods.Items[0].Spec.Containers[0].Ports[0].ContainerPort, nil
 }
 
 func getKubeClient() (*kubernetes.Clientset, error) {
@@ -77,29 +99,64 @@ func getKubeClient() (*kubernetes.Clientset, error) {
 // TODO currently just a debian pod for testing
 // TODO probably better to use a Deployment so we can keep it behind a known IP.
 // TODO DB and webserver pod templates in kubernetes/examples.  Might be useful
-func newDatabasePod(instanceID, ns string) *v1.Pod {
+func newDatabaseInstance(instanceID string) (*v1.Pod, *v1.Secret) {
+	secretName := "db-" + instanceID + "-secret"
+	isOptional := false
+
 	return &v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PodMeta",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "mongo-" + ns + "-", // to mongo // TODO generate unique but identifiable names
+			Name: "mongo-" + instanceID,
+			Labels: map[string]string{
+				INST_RESOURCE_LABEL_NAME: instanceID,
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:            "mongo",                  // to "mongo"
-					Image:           "docker.io/mongo:latest", // to "docker.io/mongo"
+					Name:            "mongo",
+					Image:           "docker.io/mongo:latest",
 					ImagePullPolicy: "IfNotPresent",
+					EnvFrom: []v1.EnvFromSource{
+						{
+							SecretRef: &v1.SecretEnvSource{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: secretName,
+								},
+								Optional: &isOptional,
+							},
+						},
+					},
+					Args: []string{"mongod"},  // TODO this is where createUser cmd will be appended
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "mongodb",
-							ContainerPort: 27017, // mongoDB port
+							ContainerPort: 27017,
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "admin-credentials",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName: secretName,
 						},
 					},
 				},
 			},
 		},
-	}
+	},
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: secretName,
+				Labels: map[string]string{
+					INST_RESOURCE_LABEL_NAME: instanceID,
+				},
+			},
+			StringData: map[string]string{
+				MONGO_INITDB_ROOT_USERNAME_NAME: MONGO_INITDB_ROOT_USERNAME_VALUE,
+				MONGO_INITDB_ROOT_PASSWORD_NAME: MONGO_INITDB_ROOT_PASSWORD_VALUE,
+			},
+		}
 }


### PR DESCRIPTION
DB in Auth Mode
To enable mongo authentication, the container needs to be started with 2 env variables set: MONGO_INITDB_ROOT_USERNAME and MONGO_INITDB_ROOT_PASSWORD. The entrypoint script run by the container examines these vars and then starts the db with auth turned on. For security, the uname and password at stored in a secret and mounted into the pod.

Decouple broker from pod management
Removing references from core broker code to kube objects. Instead, pod handling code will get and delete api resources based off commonly assigned labels. The label key will always be instanceID and the value the actual instance id. This allow for List and DeleteCollection calls using the selectorlabel. This is useful because it means we no long need the resource name beforehand, and so do not have to store it in the instanceMap.